### PR TITLE
add item bug fixed

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,15 +19,11 @@ class ItemsController < ApplicationController
       @category = Category.new
       @item.user = current_user
       if @item.save
-
         redirect_to new_item_item_category_path(@item)
-
         flash[:alert] = 'You have successfully added your item.'
-
       else
         render :new
       end
-      redirect_to item_path(@item)
     end
 
     def edit


### PR DESCRIPTION
When an item added we were getting errors. The reason was in the items_conttoller, there was a route conflict. It's fixed.
Now when the user adds an item it is taking him/her to the category page.